### PR TITLE
Visual improvements to feed entries

### DIFF
--- a/src/popup/popup.scss
+++ b/src/popup/popup.scss
@@ -62,16 +62,25 @@ nav {
     "author author date thumbnail";
   align-items: center;
 
-  cursor: pointer;
   background: $ink-70;
   margin: 0.5em;
   padding: 0.5em;
+  border-radius: 0.2rem;
 
   &:first-of-type .thumbnail {
     transform-origin: top right;
   }
   &:last-of-type .thumbnail {
     transform-origin: bottom right;
+  }
+
+  @include hover;
+  &:hover:not(:has(.read:hover)) { // applies only when the "mark read" button isn't being hovered also.
+    background: $ink-40;
+  }
+
+  &:active {
+    background: none;
   }
 }
 
@@ -88,6 +97,12 @@ $areas: "icon", "title", "read", "thumbnail", "author", "date", "thumbnail";
 
 .read {
   justify-self: flex-end;
+  padding: 0.15rem;
+  border-radius: 0.2rem;
+  @include hover;
+  &:hover {
+    background: $ink-40;
+  }
 }
 
 .author,


### PR DESCRIPTION
See my other PR: #1 

Changes to the CSS of individual feed entries:
- Added hover effects to both the entry and its 'mark read' button to make them feel more responsive.
- Applied a border radius to round-out the corners.
- Added a bit of padding to 'mark read' buttons to increase their clickable area.